### PR TITLE
:wrench: Set author/commiter for serial number updates

### DIFF
--- a/.github/workflows/update-serial.yml
+++ b/.github/workflows/update-serial.yml
@@ -72,3 +72,7 @@ jobs:
           # Arguments for the git tag command (the tag name always needs to be the first word not preceded by an hyphen)
           # Default: ''
           tag: "v${{ steps.generate-serial.outputs.serial }}"
+          # Determines the way the action fills missing author name and email.
+          default_author: github_actions
+          committer_name: "FFMD Bot"
+          committer_email: "admin+bot@md.freifunk.net"


### PR DESCRIPTION
Use the github actions bot as author and the FFMD Bot as committer for updates to the Zone Serial number.